### PR TITLE
Parse lcov with branch summaries but no branches.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,10 +3,9 @@ var fs = require('fs'),
     exists = fs.exists || path.exists;
 
 var walkFile = function(str, cb) {
-    var data = [], item = {};
+    var data = [], item;
 
-    str = str.split('\n');
-    str.forEach(function(line) {
+    [ 'end_of_record' ].concat(str.split('\n')).forEach(function(line) {
         line = line.trim();
 
         var parts = line.split(':'), lines, fn;
@@ -31,13 +30,6 @@ var walkFile = function(str, cb) {
                 item.lines.hit = Number(parts[1].trim());
                 break;
             case 'DA':
-                if (!item.lines) {
-                    item.lines = {
-                        found: 0,
-                        hit: 0,
-                        details: []
-                    };
-                }
                 lines = parts[1].split(',');
                 item.lines.details.push({
                     line: Number(lines[0]),
@@ -45,13 +37,6 @@ var walkFile = function(str, cb) {
                 });
                 break;
             case 'FN':
-                if (!item.functions) {
-                    item.functions = {
-                        hit: 0,
-                        found: 0,
-                        details: []
-                    };
-                }
                 fn = parts[1].split(',');
                 item.functions.details.push({
                     name: fn[1],
@@ -68,13 +53,6 @@ var walkFile = function(str, cb) {
                 });
                 break;
             case 'BRDA':
-                if (!item.branches) {
-                    item.branches = {
-                        hit: 0,
-                        found: 0,
-                        details: []
-                    };
-                }
                 fn = parts[1].split(',');
                 item.branches.details.push({
                     line: Number(fn[0]),
@@ -93,9 +71,28 @@ var walkFile = function(str, cb) {
 
         if (line.indexOf('end_of_record') > -1) {
             data.push(item);
-            item = {};
+            item = {
+              lines: {
+                  found: 0,
+                  hit: 0,
+                  details: []
+              },
+              functions: {
+                  hit: 0,
+                  found: 0,
+                  details: []
+              },
+              branches: {
+                hit: 0,
+                found: 0,
+                details: []
+              }
+            };
         }
     });
+
+    data.shift();
+
     if (data.length) {
         cb(null, data);
     } else {

--- a/tests/info/parts.info
+++ b/tests/info/parts.info
@@ -393,3 +393,23 @@ BRDA:82,8,1,-
 BRF:23
 BRH:22
 end_of_record
+
+TN:Test #3
+SF:javascript/common.js
+FN:2,create
+FN:3,javascript
+FNF:2
+FNH:2
+FNDA:19,create
+FNDA:2,javascript
+DA:1,19
+DA:2,19
+DA:3,19
+DA:4,2
+DA:5,2
+DA:7,0
+LF:6
+LH:5
+BRF:0
+BRH:0
+end_of_record

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -40,36 +40,44 @@ var tests = {
             assert.isNull(err);
             assert.isArray(data);
         },
-        'should contain 2 keys': function(err, data) {
-            assert.equal(data.length, 2);
+        'should contain 3 keys': function(err, data) {
+            assert.equal(data.length, 3);
         },
-        'first key should have 4 properties': function(err, data) {
-            var d = data[0];
-            assert.deepEqual(Object.keys(d), [ 'title', 'file', 'functions', 'lines' ]);
+        'first key should have 5 properties': function(err, data) {
+            var keys = Object.keys(data[0]);
+            assert.deepEqual(keys.sort(), [ 'branches', 'file', 'functions', 'lines', 'title' ])
         },
         'verify test titles': function(err, data) {
             assert.equal(data[0].title, 'Test #1');
             assert.equal(data[1].title, 'Test #2');
+            assert.equal(data[2].title, 'Test #3');
         },
         'verify test files': function(err, data) {
             assert.equal(data[0].file, 'anim-base/anim-base-coverage.js');
             assert.equal(data[1].file, 'anim-easing/anim-easing-coverage.js');
+            assert.equal(data[2].file, 'javascript/common.js');
         },
         'verify number of functions': function(err, data) {
             assert.equal(data[0].functions.found, 29);
             assert.equal(data[0].functions.hit, 23);
             assert.equal(data[1].functions.found, 17);
             assert.equal(data[1].functions.hit, 17);
+            assert.equal(data[2].functions.found, 2);
+            assert.equal(data[2].functions.hit, 2);
         },
         'verify number of branches': function(err, data) {
             assert.equal(data[1].branches.found, 23);
             assert.equal(data[1].branches.hit, 22);
             assert.equal(data[1].branches.found, data[1].branches.details.length);
             assert.equal(data[1].branches.details[data[1].branches.details.length - 1].taken, 0);
+            assert.equal(data[2].branches.found, 0);
+            assert.equal(data[2].branches.hit, 0);
+            assert.deepEqual(data[2].branches.details, []);
         },
         'verify function details': function(err, data) {
             assert.equal(data[0].functions.details.length, 29);
             assert.equal(data[1].functions.details.length, 17);
+            assert.equal(data[2].functions.details.length, 2);
             assert.deepEqual(data[0].functions.details[0], { name: '(anonymous 1)', line: 7, hit: 6 });
             assert.deepEqual(data[0].functions.details[11], { name: '_start', line: 475, hit: 231 });
 
@@ -77,6 +85,8 @@ var tests = {
             assert.deepEqual(data[0].functions.details[28], { name: 'stop', line: 389, hit: 0 });
 
             assert.deepEqual(data[1].functions.details[4], { name: 'bounceBoth', line: 345, hit: 36 });
+
+            assert.deepEqual(data[2].functions.details[1], { name: 'javascript', line: 3, hit: 2 });
 
         },
         'verify number of lines': function(err, data) {
@@ -88,11 +98,14 @@ var tests = {
         'verify line details': function(err, data) {
             assert.equal(data[0].lines.details.length, 181);
             assert.equal(data[1].lines.details.length, 76);
+            assert.equal(data[2].lines.details.length, 6);
             assert.deepEqual(data[0].lines.details[0], { line: 7, hit: 6 });
             assert.deepEqual(data[0].lines.details[10], { line: 91, hit: 6 });
 
             assert.deepEqual(data[1].lines.details[20], { line: 157, hit: 32 });
             assert.deepEqual(data[1].lines.details[64], { line: 313, hit: 51 });
+
+            assert.deepEqual(data[2].lines.details[2], { line: 3, hit: 19 });
         },
 
     }


### PR DESCRIPTION
Parse an `lcov.info` file that contains `BRF` and `BRH` records but no `BRDA` records. To support this, each `item` object is created with a `branches` property. The `branches` property is not only created if needed. To determine if there are no branches in an `item` object, instead of testing for the absence of the `branches` property, the user should instead to the `found` property of the `branches` property.

See #3.
