### PR TITLE
Fixed windows file path issues

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,8 +13,9 @@ var walkFile = function(str, cb) {
 
     [ 'end_of_record' ].concat(str.split('\n')).forEach(function(line) {
         line = line.trim();
-
-        var parts = line.split(':'), lines, fn;
+        var allparts = line.split(':');
+		var parts = [allparts.shift(), allparts.join(':')];
+        var lines, fn;
 
         switch (parts[0].toUpperCase()) {
             case 'TN':


### PR DESCRIPTION
Only the first ':' should be split. Because this is valid lcov:

SF:C:\Users\fru\Desktop...
