### PR TITLE
Export .source() - Never checks fs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,3 +123,4 @@ var parse = function(file, cb) {
 
 
 module.exports = parse;
+module.exports.source = walkFile;


### PR DESCRIPTION
I've got a case where anyone can specify the source through an API. However I don't want them able to specify "source" that's in fact a path of a potentially private file such as a config file on the server.

By using `lcovParser.source(stringHere)` I can negate the vulnerability.
