### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+tests
+.travis.yml


### PR DESCRIPTION
We don't need .travis.yml or tests in the built npm package.