### PR TITLE
Add power support ppc64le and update versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
 language: node_js
+
 node_js:
-    - "0.10"
-    - "0.11"
+    - "8"
+    - "10"
+    - "12"
+    - "14"
+    
+arch:
+    - amd64
+    - ppc64le
+
+before_install:
+     - if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then    sudo apt-get install npm;   fi


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. Also updated the nodejs versions to latest.