### PR TITLE
Fixes end_of_record check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ var walkFile = function(str, cb) {
                 break;
         }
 
-        if (line.indexOf('end_of_record') > -1) {
+        if (line.trimStart().indexOf('end_of_record') == 0) {
             data.push(item);
             item = {
               lines: {


### PR DESCRIPTION
Hi Dav, sorry to bother you with a pull request on a repo that isn't touched much these days. This should be pretty simple though. If you have anything with "end_of_record" in its name in the coverage, this condition would return true and fail to parse the coverage report correctly. Found this out the hard way!